### PR TITLE
Make ViewPort a fixed window when at end of range.

### DIFF
--- a/aptana/ctl/crds.html
+++ b/aptana/ctl/crds.html
@@ -181,8 +181,22 @@
 					x : d.getTime(),
 					y : data[data.length - 1].y + 4 * Math.random() - 2.0
 				});
-				chart.update();
-			}, 1000);
+
+                // Update the chart so that if the currently viewed window ends at
+                // the most recent data point, the window of viewed data 'slides' so
+                // the most recent data points are always shown.
+                currentExtent = chart.brushExtent();
+                dataEnd = data[0].x;
+                prevDataEnd = data[1].x;
+                if (currentExtent && (currentExtent[1] == prevDataEnd)) {
+                    delta = dataEnd - prevDataEnd;
+                    newStart = currentExtent[0] + delta;
+                    newEnd = dataEnd;
+                    chart.brushExtent([newStart, newEnd]).update();
+                } else {
+                    chart.update();
+                }
+            }, 1000);
 
 		</script>
 	</body>


### PR DESCRIPTION
When the "ViewPort" into the plot is at the end of the time range, make it "fixed", so that instead of sliding, it always looks at the last section of data.

If the ViewPort does not include the end of the time range, I don't mess with it, which I think is the behavior that you want: if you are zoomed in on a section of data from earlier in the day, you want to stay zoomed in on exactly that range. If you don't like this behavior, it can be changed easily.

Uses chart.brushExtent(), which I disovered here:

http://stackoverflow.com/questions/16852401/how-to-change-the-viewfinder-focus-chart-of-a-nvd3-line-chart-programmatically

Let me know whether this works for you.

Dan